### PR TITLE
fix(output): fix bug of "always creating dump instances using the first output preset mode

### DIFF
--- a/frontend/md_simulation.cpp
+++ b/frontend/md_simulation.cpp
@@ -22,8 +22,8 @@ MDSimulation::MDSimulation(ConfigValues *p_config_values)
 }
 
 void MDSimulation::onSimulationStarted() {
-    for (const DumpConfig preset : pConfigVal->output.presets) {
-        switch (pConfigVal->output.presets[0].mode) {
+    for (const DumpConfig &preset : pConfigVal->output.presets) {
+        switch (preset.mode) {
             case OutputMode::DEBUG:
                 this->dump_instances[preset.name] = new OutputDump(preset, *_p_domain);
                 break;


### PR DESCRIPTION

The output "mode" in output preset can be `debug` or `copy`. Before this fix, dump instances are
always created using the output mode of the first output preset.  
This commit fixed this bug.