### PR TITLE
Feature memory layout improve: allow AoS or SoA memory layout

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -22,6 +22,7 @@ set(MD_TH_ARCH_SRC_PATH "" CACHE PATH "Source files directory of TianHe-3 archit
 set(MD_CUDA_ARCH_SRC_PATH "" CACHE PATH "Source directory of CUDA architecture code") # source file directory of cuda arch code.
 set(MD_HIP_ARCH_SRC_PATH "" CACHE PATH "Source directory of HIP architecture code") # source file directory of hip arch code.
 
+set(MD_ATOMS_MEMORY_LAYOUT "default" CACHE STRING "memory layout for atoms, can be: soa/aos/default")
 set(MD_RAND "MT" CACHE STRING "random number generating algorithm") # random number generating
 # options are:
 #   LCG: linear congruential

--- a/src/configure.cmake
+++ b/src/configure.cmake
@@ -21,6 +21,19 @@ if (MD_RUNTIME_CHECKING_FLAG)
     set(MD_RUNTIME_CHECKING ON)
 endif ()
 
+# set kernel strategy.
+string(TOLOWER ${MD_ATOMS_MEMORY_LAYOUT} MD_ATOMS_MEMORY_LAYOUT_LOWER)
+if (MD_ATOMS_MEMORY_LAYOUT_LOWER MATCHES "default")
+    set(MD_ATOM_HASH_ARRAY_MEMORY_LAYOUT_AOS ON) # default memory layout is AoS
+elseif (MD_ATOMS_MEMORY_LAYOUT_LOWER MATCHES "soa")
+    set(MD_ATOM_HASH_ARRAY_MEMORY_LAYOUT_SOA ON)
+elseif (MD_ATOMS_MEMORY_LAYOUT_LOWER MATCHES "aos")
+    set(MD_ATOM_HASH_ARRAY_MEMORY_LAYOUT_AOS ON)
+else ()
+    MESSAGE(FATAL_ERROR "unsupported kernel strategy ${MD_ATOMS_MEMORY_LAYOUT}")
+endif ()
+MESSAGE(STATUS "current kernel strategy is: ${MD_ATOMS_MEMORY_LAYOUT}")
+
 configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/md_building_config.h.in"
         "${CONFIGURE_GENERATED_PATH}/md_building_config.h"

--- a/src/md_building_config.h.in
+++ b/src/md_building_config.h.in
@@ -8,7 +8,8 @@
 #ifndef MISA_MD_PRE_CONFIG_H
 #define MISA_MD_PRE_CONFIG_H
 
-#define MD_ATOM_HASH_ARRAY_MEMORY_LAYOUT_AOS // array of struct memory layout
+#cmakedefine MD_ATOM_HASH_ARRAY_MEMORY_LAYOUT_AOS // array of struct memory layout
+#cmakedefine MD_ATOM_HASH_ARRAY_MEMORY_LAYOUT_SOA // struct of array memory layout
 
 #cmakedefine MD_DEV_MODE
 #cmakedefine MD_RUNTIME_CHECKING // run data checking at runtimee


### PR DESCRIPTION
we can now specific SoA or AoS memory layout for atoms by cmake variable `MD_ATOMS_MEMORY_LAYOUT`.