### PR TITLE
fix(io): fix unexpected MPI-IO behavior in copy output mode under OpeMPI

### DIFF
--- a/frontend/io/atom_dump_types.cpp
+++ b/frontend/io/atom_dump_types.cpp
@@ -75,8 +75,11 @@ MPI_Datatype atom_dump::registerAtomDumpMPIDataType(const type_dump_mask mask) {
     MPI_TYPE_OP_CHECK(MPI_Type_create_struct(3, block_lengths, offsets, types, &l_mpi_dump_type))
     MPI_TYPE_OP_CHECK(MPI_Type_commit(&l_mpi_dump_type))
 
-    mpi_dump_types[mask] = l_mpi_dump_type;
-    return l_mpi_dump_type;
+    MPI_Datatype ext_l_mpi_dump_type = MPI_DATATYPE_NULL;
+    MPI_TYPE_OP_CHECK(MPI_Type_create_resized(l_mpi_dump_type, 0, sizeof(atom_dump::AtomInfoDump), &ext_l_mpi_dump_type));
+
+    mpi_dump_types[mask] = ext_l_mpi_dump_type;
+    return ext_l_mpi_dump_type;
 }
 
 MPI_Datatype atom_dump::registerFrameMetaMPIDataType() {


### PR DESCRIPTION
Here, the observational unexpected MPI-IO behavior is: the md-tools conversion tool does
not exit with a very large text file (data stored in the  MD output binary file is incorrect).
The behavior is cause by the incorrect extent, as well as upper/lower bounds, of the derived
MPI Datatype, which causes different size calculated by `MPI_Type_size` under MPICH and OpenMPI
(in MPICH, the conversion result is as our expected, but in OpenMP it does not.)

This can be easily fixed by adding `MPI_Type_create_resized`.